### PR TITLE
Fix Sensors init/reinit for multi-gpu configurations

### DIFF
--- a/ViewModels/MainWindowViewModel.Sensors.cs
+++ b/ViewModels/MainWindowViewModel.Sensors.cs
@@ -156,6 +156,25 @@ public partial class MainWindowViewModel
         _sensorTimer.Start();
     }
 
+    private void ChangeGpuReinitSensors()
+    {
+        if (_sensorTimer != null)
+        {
+            _sensorTimer.Stop();
+            _sensorTimer.Tick -= SensorTimer_Tick;
+            _sensorTimer = null;
+        }
+        Sensors = null;
+
+        InitSensors();
+
+        if (IsLogEnabled)
+        {
+            WriteLogHeader();
+        }
+
+    }
+
     private void SensorTimer_Tick(object? sender, EventArgs e)
     {
         if (_selectedGpu == null) return;

--- a/ViewModels/MainWindowViewModel.cs
+++ b/ViewModels/MainWindowViewModel.cs
@@ -331,7 +331,6 @@ public partial class MainWindowViewModel : ViewModelBase
             };
         }
 
-        InitSensors();
     }
 
     #endregion
@@ -378,8 +377,8 @@ public partial class MainWindowViewModel : ViewModelBase
         if (value != null)
         {
             LoadGpuData(value.Id);
-            if (IsLogEnabled) WriteLogHeader();
-        }
+            ChangeGpuReinitSensors();
+        }        
     }
 
     partial void OnSelectedTabIndexChanged(int value)


### PR DESCRIPTION
With multi-gpu configurations the sensors initialization occurred only one time, after launching the program. It has been modified so every time the GPU is changed - the sensors are reinitialized.