### PR TITLE
Fix OpenGL string (Graphics Card tab)

### DIFF
--- a/Views/GeneralView.axaml
+++ b/Views/GeneralView.axaml
@@ -281,7 +281,7 @@
                      <TextBlock Text="PhysX" Classes="CheckText" Opacity="0.5"/>
                      
                      <CheckBox IsChecked="{Binding IsOpenglEnabled}" Classes="GpuZ"/>
-                     <TextBlock Text="OpenGL 4.6" Classes="CheckText"/>
+                     <TextBlock Text="OpenGL" Classes="CheckText"/>
                  </StackPanel>
             </StackPanel>
         </Grid>


### PR DESCRIPTION
Fixes #3 by simply omitting OpenGL version. This is consistent with the rest of technologies shown (none of them has version displayed) and the OpenGL version is available via Advanced tab.