### PR TITLE
Main tab - dynamic GPU performance metrics (AMD)

### DIFF
--- a/Models/GpuSensorData.cs
+++ b/Models/GpuSensorData.cs
@@ -27,8 +27,13 @@ public record GpuSensorData
     
     // Overclocking offsets read from NVAPI sidecar - they allow to show proper clocks at GPU-T runtime
     // plus they can be used to recalculate pixel fillrate and bandwidth values on the fly (main tab)
-    public int CoreOcOffset { get; set; }
-    public int MemOcOffset { get; set; }
+    public int NVIDIA_CoreOcOffset { get; set; }
+    public int NVIDIA_MemOcOffset { get; set; }
+
+    // For AMD GPUs we're probing the actual clocks, not offsets like with NVIDIA
+    public int AMD_CoreReadValue { get; set; }
+    public int AMD_MemReadValue { get; set; }
+    public int AMD_BoostReadValue { get; set; }
 
     //Allows to update the PCIe link status dynamically
     public string BusInterface { get; set; } = "N/A";

--- a/Services/Probes/LinuxAmd/LinuxAmdGpuProbe.Helpers.cs
+++ b/Services/Probes/LinuxAmd/LinuxAmdGpuProbe.Helpers.cs
@@ -1,4 +1,5 @@
 using System.IO;
+using System.Globalization;
 using System.Text.RegularExpressions;
 
 namespace GPU_T.Services.Probes.LinuxAmd;
@@ -8,6 +9,85 @@ namespace GPU_T.Services.Probes.LinuxAmd;
 /// </summary>
 public partial class LinuxAmdGpuProbe
 {
+    
+    /// <summary>
+    /// Calculates the actual current GPU clock, boost clock, memory clock, pixel fillrate, texture fillrate, and bandwidth
+    /// using AMD's DPM states and OverDrive limits.
+    /// </summary>
+    public static (string GpuClock, string BoostClock, string MemClock, string PixelFill, string TexFill, string Bandwidth) 
+        CalculateDynamicSpecs(
+            double maxCoreDpm, double maxMemDpm, double odSclk,
+            double baseClock, double boostClock, double memClock,
+            double rops, double tmus, double busWidth, string memoryType)
+    {
+        string gpuClock = "---";
+        string boostClockDisplay = "---";
+        string memClockDisplay = "---";
+        string pixelFill = "N/A";
+        string texFill = "N/A";
+        string bandwidth = "N/A";
+
+        double actualBoost = 0;
+
+        if (maxCoreDpm > 0)
+        {
+            string coreStr = $"{maxCoreDpm.ToString(CultureInfo.InvariantCulture)} MHz";
+            gpuClock = coreStr;
+            boostClockDisplay = coreStr;
+            actualBoost = maxCoreDpm;
+        }
+
+        if (maxMemDpm > 0)
+        {
+            string memStr = $"{maxMemDpm.ToString(CultureInfo.InvariantCulture)} MHz";
+            memClockDisplay = memStr;
+        }
+
+        if (odSclk > 0)
+        {
+            actualBoost = odSclk;
+            boostClockDisplay = $"{odSclk.ToString(CultureInfo.InvariantCulture)} MHz";
+        }
+        else if (maxCoreDpm > 0 && boostClock > 0 && baseClock > 0)
+        {
+            double diff = boostClock - baseClock;
+            
+            // prevent unrealistically high boost clocks for iGPUs - ignore the logic if max DPM clock is more than double the base (DB) clock
+            if (maxCoreDpm / baseClock < 2)
+            {
+                actualBoost = maxCoreDpm + diff;
+                boostClockDisplay = $"{actualBoost.ToString(CultureInfo.InvariantCulture)} MHz";
+            } 
+            else if (boostClock > maxCoreDpm)
+            {
+                boostClockDisplay = $"{boostClock.ToString(CultureInfo.InvariantCulture)} MHz";
+                actualBoost = boostClock;
+            }
+        } //fallback to static boost clock
+        else if (boostClock > 0 && maxCoreDpm <= 0)
+        {
+            boostClockDisplay = $"{boostClock.ToString(CultureInfo.InvariantCulture)} MHz";
+            actualBoost = boostClock;
+        }
+
+        if (actualBoost > 0 && rops > 0 && tmus > 0)
+        {
+            pixelFill = $"{(actualBoost * rops / 1000.0).ToString("0.0", CultureInfo.InvariantCulture)} GPixel/s";
+            texFill = $"{(actualBoost * tmus / 1000.0).ToString("0.0", CultureInfo.InvariantCulture)} GTexel/s";
+        }
+
+        double currentMemForBandwidth = maxMemDpm > 0 ? maxMemDpm : memClock;
+        if (currentMemForBandwidth > 0 && busWidth > 0)
+        {
+            double multiplier = CommonGpuHelpers.GetMemoryMultiplier(memoryType);
+            double bandwidthValue = (currentMemForBandwidth * multiplier * busWidth) / 8000.0;
+            bandwidth = $"{bandwidthValue.ToString("0.0", CultureInfo.InvariantCulture)} GB/s";
+        }
+
+        return (gpuClock, boostClockDisplay, memClockDisplay, pixelFill, texFill, bandwidth);
+    }
+    
+    
     /// <summary>
     /// Reads the contents of a file in the GPU sysfs base path, returning a fallback value if unavailable.
     /// </summary>

--- a/Services/Probes/LinuxAmd/LinuxAmdGpuProbe.Sensors.cs
+++ b/Services/Probes/LinuxAmd/LinuxAmdGpuProbe.Sensors.cs
@@ -105,6 +105,18 @@ public partial class LinuxAmdGpuProbe
         double cpuTemp = CommonGpuHelpers.GetCpuTemperature();
         double sysRam = CommonGpuHelpers.GetSystemRamUsage();
 
+
+        double maxCoreDpm = GetMaxClockFromDpm("pp_dpm_sclk");
+
+        var odClocks = GetMaxClocksFromOd("pp_od_clk_voltage");
+
+        double maxMemDpm = odClocks.Mclk * _memClockMultiplier;
+        if (maxMemDpm <= 0)
+            maxMemDpm = GetMaxClockFromDpm("pp_dpm_mclk") * _memClockMultiplier;
+
+        double boostClock = odClocks.Sclk;
+
+
         // Sensor label parsing and assignment logic ensures correct mapping for edge, hotspot, and memory temperatures.
         // Fan percentage is calculated from PWM values if available.
         // Power and voltage readings are normalized to standard units.
@@ -127,6 +139,9 @@ public partial class LinuxAmdGpuProbe
             MemoryUsedDynamic = memGttMb,
             CpuTemperature = cpuTemp,
             SystemRamUsed = sysRam,
+            AMD_CoreReadValue = (int)maxCoreDpm,
+            AMD_MemReadValue = (int)maxMemDpm,
+            AMD_BoostReadValue = (int)boostClock,
             BusInterface = GpuFeatureDetection.GetPcieInfo(_basePath)
         };
     }

--- a/Services/Probes/LinuxAmd/LinuxAmdGpuProbe.Static.cs
+++ b/Services/Probes/LinuxAmd/LinuxAmdGpuProbe.Static.cs
@@ -72,33 +72,24 @@ public partial class LinuxAmdGpuProbe
 
         bool isOpenClAvailable = GpuFeatureDetection.CheckOpenClIcdInstalled("amdocl64.icd", "mesa.icd", "rusticl.icd");
 
-        string pixelFill = "N/A";
-        string texFill = "N/A";
-        string bandwidth = "N/A";
+        //string pixelFill = "N/A";
+        //string texFill = "N/A";
+        //string bandwidth = "N/A";
         string ropsTmus = "N/A";
         string lookupUrl = "";
 
-        string gpuClock = "---";
-        string boostClockDisplay = "---";
-        string memClockDisplay = "---";
+        //string gpuClock = "---";
+        //string boostClockDisplay = "---";
+        //string memClockDisplay = "---";
 
-        string defaultGpuClockDb = "N/A";
+        //string defaultGpuClockDb = "N/A";
 
         double actualBoost = 0;
 
-        if (maxCoreDpm > 0)
-        {
-            string coreStr = $"{maxCoreDpm.ToString(CultureInfo.InvariantCulture)} MHz";
-            gpuClock = coreStr;
-            boostClockDisplay = coreStr;
-            actualBoost = maxCoreDpm;
-        }
+        (string GpuClock, string BoostClock, string MemClock, 
+         string PixelFill, string TexFill, string Bandwidth) dynamicSpecs = ("---", "---", "---", "N/A", "N/A", "N/A");
 
-        if (maxMemDpm > 0)
-        {
-            string memStr = $"{maxMemDpm.ToString(CultureInfo.InvariantCulture)} MHz";
-            memClockDisplay = memStr;
-        }
+        string defaultGpuClockDb = "N/A";
 
         if (spec != null)
         {
@@ -120,45 +111,18 @@ public partial class LinuxAmdGpuProbe
 
             double baseClock = CommonGpuHelpers.ExtractNumber(defaultGpuClockDb);
 
-            if (odClocks.Sclk > 0)
-            {
-                actualBoost = odClocks.Sclk;
-                boostClockDisplay = $"{odClocks.Sclk.ToString(CultureInfo.InvariantCulture)} MHz";
-            }
-            else if (maxCoreDpm > 0 && boostClock > 0 && baseClock > 0)
-            {
-                double diff = boostClock - baseClock;
-                
-                if (maxCoreDpm / baseClock < 2)
-                {
-                    actualBoost = maxCoreDpm + diff;
-                    boostClockDisplay = $"{actualBoost.ToString(CultureInfo.InvariantCulture)} MHz";
-                } else if(boostClock > maxCoreDpm)
-                {
-                    boostClockDisplay = $"{boostClock.ToString(CultureInfo.InvariantCulture)} MHz";
-                    actualBoost = boostClock;
-                }
-            } //fallback to static boost clock
-            else if (boostClock > 0 && maxCoreDpm <=0)
-            {
-                boostClockDisplay = $"{boostClock.ToString(CultureInfo.InvariantCulture)} MHz";
-                actualBoost = boostClock;
-            }
-
-
-            if (actualBoost > 0 && rops > 0 && tmus > 0)
-            {
-                pixelFill = $"{(actualBoost * rops / 1000.0).ToString("0.0", CultureInfo.InvariantCulture)} GPixel/s";
-                texFill = $"{(actualBoost * tmus / 1000.0).ToString("0.0", CultureInfo.InvariantCulture)} GTexel/s";
-            }
-
-            double currentMemForBandwidth = maxMemDpm > 0 ? maxMemDpm : memClock;
-            if (currentMemForBandwidth > 0 && busWidth > 0)
-            {
-                double multiplier = CommonGpuHelpers.GetMemoryMultiplier(spec.MemoryType);
-                double bandwidthValue = (currentMemForBandwidth * multiplier * busWidth) / 8000.0;
-                bandwidth = $"{bandwidthValue.ToString("0.0", CultureInfo.InvariantCulture)} GB/s";
-            }
+            // Trigger our new helper to calculate everything dynamically
+            dynamicSpecs = CalculateDynamicSpecs(
+                maxCoreDpm, maxMemDpm, odClocks.Sclk,
+                baseClock, boostClock, memClock,
+                rops, tmus, busWidth, spec.MemoryType);
+        }
+        else
+        {
+            // Even if the DB spec is missing, pass 0s to format the sysfs DPM clock reads correctly!
+            dynamicSpecs = CalculateDynamicSpecs(
+                maxCoreDpm, maxMemDpm, odClocks.Sclk,
+                0, 0, 0, 0, 0, 0, "");
         }
 
         return new GpuStaticData
@@ -186,19 +150,19 @@ public partial class LinuxAmdGpuProbe
             RopsTmus = ropsTmus,
             Shaders = spec?.Shaders ?? "N/A",
             ComputeUnits = spec?.ComputeUnits ?? "N/A",
-            PixelFillrate = pixelFill,
-            TextureFillrate = texFill,
+            PixelFillrate = dynamicSpecs.PixelFill,
+            TextureFillrate = dynamicSpecs.TexFill,
             MemoryType = finalMemType,
             BusWidth = spec?.BusWidth ?? "N/A",
             MemorySize = finalMemorySize,
-            Bandwidth = bandwidth,
+            Bandwidth = dynamicSpecs.Bandwidth,
             DefaultGpuClock = defaultGpuClockDb,
             DefaultBoostClock = spec?.DefBoostClock ?? "N/A",
             DefaultMemoryClock = spec?.DefMemClock ?? "N/A",
 
-            CurrentGpuClock = gpuClock,
-            BoostClock = boostClockDisplay,
-            CurrentMemClock = memClockDisplay,
+            CurrentGpuClock = dynamicSpecs.GpuClock,
+            BoostClock = dynamicSpecs.BoostClock,
+            CurrentMemClock = dynamicSpecs.MemClock,
 
             IsHsaAvailable = isHipAvailable,
             IsRocmAvailable = isRocmAvailable,

--- a/Services/Probes/LinuxNvidia/LinuxNvidiaGpuProbe.Sensors.cs
+++ b/Services/Probes/LinuxNvidia/LinuxNvidiaGpuProbe.Sensors.cs
@@ -152,8 +152,8 @@ public partial class LinuxNvidiaGpuProbe
                 FanPercent = (int)fanPercent, BoardPower = powerW, GpuLoad = gpuLoad, MemControllerLoad = memLoad,
                 MemoryUsed = memUsedMb, GpuVoltage = GpuVoltage, MemoryTemp = memTemp, EncoderLoad = encLoad,
                 DecoderLoad = decLoad, PerfCapReason = perfCap, PcieTx = pcieTxGb, PcieRx = pcieRxGb,
-                CoreOcOffset = coreOcOffset,
-                MemOcOffset = memOcOffset,
+                NVIDIA_CoreOcOffset = coreOcOffset,
+                NVIDIA_MemOcOffset = memOcOffset,
                 FanRpm = fanRpm,
                 // These read fast local files, so we keep them in the background thread too!
                 CpuTemperature = CommonGpuHelpers.GetCpuTemperature(),

--- a/ViewModels/MainWindowViewModel.Sensors.cs
+++ b/ViewModels/MainWindowViewModel.Sensors.cs
@@ -248,11 +248,11 @@ public partial class MainWindowViewModel
         }
 
         // If we detect a change in overclocking offsets, we recalculate the dynamic specs which depend on them and update the main tab values accordingly.
-        // (Right now NVIDIA only)
-        if(data.CoreOcOffset != _lastCoreOffset || data.MemOcOffset != _lastMemOffset)
+        // (NVIDIA block)
+        if(data.NVIDIA_CoreOcOffset != _lastNvidiaCoreOffset || data.NVIDIA_MemOcOffset != _lastNvidiaMemOffset)
         {
-            _lastCoreOffset = data.CoreOcOffset;
-            _lastMemOffset = data.MemOcOffset;
+            _lastNvidiaCoreOffset = data.NVIDIA_CoreOcOffset;
+            _lastNvidiaMemOffset = data.NVIDIA_MemOcOffset;
 
             //var memOcOffsetEffective = (int)(data.MemOcOffset * GPU_T.Services.Probes.CommonGpuHelpers.GetMemoryMultiplier(_rawMemoryType));
 
@@ -261,7 +261,7 @@ public partial class MainWindowViewModel
                 var dynamicSpecs = GPU_T.Services.Probes.LinuxNvidia.LinuxNvidiaGpuProbe.CalculateDynamicSpecs(
                     _rawDefGpuClock, _rawDefBoostClock, _rawDefMemClock,
                     _rawRops, _rawTmus, _rawBusWidth, _rawMemoryType,
-                    data.CoreOcOffset, data.MemOcOffset);
+                    data.NVIDIA_CoreOcOffset, data.NVIDIA_MemOcOffset);
 
                 // These update the Main Tab ObservableProperties
                 GpuClock = dynamicSpecs.GpuClock;
@@ -273,6 +273,33 @@ public partial class MainWindowViewModel
             }
 
         }
+
+        // If we detect a change in AMD GPU clocks, we recalculate the dynamic specs which depend on them and update the main tab values accordingly.
+        // (AMD block)
+        if(data.AMD_BoostReadValue != _lastAmdBoostRead || data.AMD_CoreReadValue != _lastAmdCoreRead || data.AMD_MemReadValue != _lastAmdMemRead)
+        {
+            _lastAmdBoostRead = data.AMD_BoostReadValue;
+            _lastAmdCoreRead = data.AMD_CoreReadValue;
+            _lastAmdMemRead = data.AMD_MemReadValue;
+
+            if (_currentVendorName == "AMD")
+            {
+                var dynamicSpecs = GPU_T.Services.Probes.LinuxAmd.LinuxAmdGpuProbe.CalculateDynamicSpecs(
+                    data.AMD_CoreReadValue, data.AMD_MemReadValue, data.AMD_BoostReadValue,
+                    _rawDefGpuClock, _rawDefBoostClock, _rawDefMemClock,
+                    _rawRops, _rawTmus, _rawBusWidth, _rawMemoryType);
+
+                // These update the Main Tab ObservableProperties
+                GpuClock = dynamicSpecs.GpuClock;
+                BoostClock = dynamicSpecs.BoostClock;
+                MemoryClock = dynamicSpecs.MemClock;
+                PixelFillrate = dynamicSpecs.PixelFill;
+                TextureFillrate = dynamicSpecs.TexFill;
+                Bandwidth = dynamicSpecs.Bandwidth;
+            }
+        }
+
+
 
         // PCIe link status can change dynamically; if we detect a change, we update the displayed value
         if(data.BusInterface != _lastBusInterface)

--- a/ViewModels/MainWindowViewModel.cs
+++ b/ViewModels/MainWindowViewModel.cs
@@ -30,8 +30,11 @@ public partial class MainWindowViewModel : ViewModelBase
     private double _rawDefGpuClock, _rawDefBoostClock, _rawDefMemClock;
     private double _rawRops, _rawTmus, _rawBusWidth;
     private string _rawMemoryType = "";
-    private int _lastCoreOffset = 0;
-    private int _lastMemOffset = 0;
+    private int _lastNvidiaCoreOffset = 0;
+    private int _lastNvidiaMemOffset = 0;
+    private int _lastAmdCoreRead = 0;
+    private int _lastAmdMemRead = 0;
+    private int _lastAmdBoostRead = 0;
     private string _lastBusInterface = "N/A";
 
     /// <summary>


### PR DESCRIPTION
This PR brings dynamic updates of various parameters like GPU clocks (OC-dependent), pixel fillrate etc. on the Main tab for AMD GPUs to have the parity of features (same as NVIDIA GPUs).