### PR TITLE
Fix Vulkan detection (Main tab)

### DIFF
--- a/Services/Probes/LinuxAmd/LinuxAmdGpuProbe.Static.cs
+++ b/Services/Probes/LinuxAmd/LinuxAmdGpuProbe.Static.cs
@@ -49,9 +49,9 @@ public partial class LinuxAmdGpuProbe
         string busInterface = GpuFeatureDetection.GetPcieInfo(_basePath);
         string reBarState = CheckResizableBar();
 
-        string driverVer = GpuFeatureDetection.GetRealDriverVersion();
+        string driverVer = GpuFeatureDetection.GetRealDriverVersion(ids.Device);
         string driverDate = GpuFeatureDetection.GetKernelDriverDate();
-        string vulkanApi = GpuFeatureDetection.GetVulkanApiVersion();
+        string vulkanApi = GpuFeatureDetection.GetVulkanApiVersion(ids.Device);
 
         var odClocks = GetMaxClocksFromOd("pp_od_clk_voltage");
 
@@ -166,7 +166,7 @@ public partial class LinuxAmdGpuProbe
 
             IsHsaAvailable = isHipAvailable,
             IsRocmAvailable = isRocmAvailable,
-            IsVulkanAvailable = vulkanApi != "N/A" || GpuFeatureDetection.CheckVulkanIcdInstalled("radeon_icd.x86_64.json", "radeon_icd.i686.json"),
+            IsVulkanAvailable = GpuFeatureDetection.CheckVulkanSupport(ids.Device, "radeon_icd.x86_64.json", "radeon_icd.i686.json"),
             IsOpenClAvailable = isOpenClAvailable,
             IsUefiAvailable = Directory.Exists("/sys/firmware/efi"),
 

--- a/Services/Probes/LinuxIntel/LinuxIntelGpuProbe.cs
+++ b/Services/Probes/LinuxIntel/LinuxIntelGpuProbe.cs
@@ -103,10 +103,10 @@ public class LinuxIntelGpuProbe : IGpuProbe
         // Memory: integrated GPUs use shared system RAM
         string memorySize = "System Shared";
 
-        string driverVersion = GpuFeatureDetection.GetRealDriverVersion();
+        string driverVersion = GpuFeatureDetection.GetRealDriverVersion(ids.Device);
         string driverDate = GpuFeatureDetection.GetKernelDriverDate();
         string busInterface = GpuFeatureDetection.GetPcieInfo(_basePath);
-        string vulkanApi = GpuFeatureDetection.GetVulkanApiVersion();
+        string vulkanApi = GpuFeatureDetection.GetVulkanApiVersion(ids.Device);
 
         bool isOpenglAvailable = GpuFeatureDetection.CheckOpenglSupport();
         bool isRayTracingAvailable = GpuFeatureDetection.CheckRayTracingSupportVulkan(ids.Device);
@@ -155,7 +155,7 @@ public class LinuxIntelGpuProbe : IGpuProbe
             CurrentMemClock = "N/A",
 
             IsOpenClAvailable = isOpenClAvailable,
-            IsVulkanAvailable = vulkanApi != "N/A" || GpuFeatureDetection.CheckVulkanIcdInstalled("intel_icd.x86_64.json", "intel_icd.i686.json", "intel_hasvk.json"),
+            IsVulkanAvailable = GpuFeatureDetection.CheckVulkanSupport(ids.Device, "intel_icd.x86_64.json", "intel_icd.i686.json", "intel_hasvk.json"),
             IsOpenglAvailable = isOpenglAvailable,
             IsRayTracingAvailable = isRayTracingAvailable,
             IsUefiAvailable = Directory.Exists("/sys/firmware/efi"),

--- a/Services/Probes/LinuxNvidia/LinuxNvidiaGpuProbe.Static.cs
+++ b/Services/Probes/LinuxNvidia/LinuxNvidiaGpuProbe.Static.cs
@@ -98,7 +98,7 @@ public partial class LinuxNvidiaGpuProbe
             deviceName = spec.Name;
 
         string busInterface = GpuFeatureDetection.GetPcieInfo(_basePath);
-        string vulkanApi = GpuFeatureDetection.GetVulkanApiVersion();
+        string vulkanApi = GpuFeatureDetection.GetVulkanApiVersion(ids.Device);
         string driverDate = GpuFeatureDetection.GetNvidiaDriverDate();
 
         bool isOpenglAvailable = GpuFeatureDetection.CheckOpenglSupport();
@@ -210,7 +210,7 @@ public partial class LinuxNvidiaGpuProbe
 
             IsCudaAvailable = isCudaAvailable,
             IsPhysXEnabled = isPhysXEnabled,
-            IsVulkanAvailable = vulkanApi != "N/A" || GpuFeatureDetection.CheckVulkanIcdInstalled("nvidia_icd.json", "nvidia_icd.x86_64.json"),
+            IsVulkanAvailable = GpuFeatureDetection.CheckVulkanSupport(ids.Device, "nvidia_icd.json", "nvidia_icd.x86_64.json"),
             IsOpenClAvailable = isOpenClAvailable,
             IsOpenglAvailable = isOpenglAvailable,
             IsHsaAvailable = false,     //we treat HIP as AMD-specific (user-perspective!)

--- a/Services/Utilities/GpuFeatureDetection.cs
+++ b/Services/Utilities/GpuFeatureDetection.cs
@@ -130,8 +130,9 @@ public static class GpuFeatureDetection
 
     /// <summary>
     /// Retrieves the Vulkan API version using vulkaninfo --summary.
+    /// If deviceIdHex is provided, it extracts the version specifically for that GPU.
     /// </summary>
-    public static string GetVulkanApiVersion()
+    public static string GetVulkanApiVersion(string deviceIdHex = "")
     {
         try
         {
@@ -144,9 +145,31 @@ public static class GpuFeatureDetection
             {
                 string output = p.StandardOutput.ReadToEnd();
                 p.WaitForExit();
-
-                var match = Regex.Match(output, @"apiVersion\s*=\s*.*?(\d+\.\d+(?:\.\d+)?)");
-                if (match.Success) return match.Groups[1].Value;
+                
+                if (!string.IsNullOrEmpty(deviceIdHex))
+                {
+                    string target = deviceIdHex.Replace("0x", "").Trim().ToUpper();
+                    var gpuBlocks = Regex.Split(output, @"GPU\d+:");
+                    
+                    for (int i = 1; i < gpuBlocks.Length; i++)
+                    {
+                        var block = gpuBlocks[i];
+                        var devMatch = Regex.Match(block, @"deviceID\s*=\s*0x([0-9a-fA-F]+)", RegexOptions.IgnoreCase);
+                        
+                        if (devMatch.Success && devMatch.Groups[1].Value.ToUpper() == target)
+                        {
+                            var apiMatch = Regex.Match(block, @"apiVersion\s*=\s*.*?(\d+\.\d+(?:\.\d+)?)");
+                            if (apiMatch.Success) return apiMatch.Groups[1].Value;
+                        }
+                    }
+                    // Target was specified but not found. Do not return another GPU's API version.
+                }
+                else
+                {
+                    // Fallback to first match ONLY if no specific target was requested
+                    var fallbackMatch = Regex.Match(output, @"apiVersion\s*=\s*.*?(\d+\.\d+(?:\.\d+)?)");
+                    if (fallbackMatch.Success) return fallbackMatch.Groups[1].Value;
+                }
             }
         }
         catch { }
@@ -155,8 +178,9 @@ public static class GpuFeatureDetection
 
     /// <summary>
     /// Retrieves the real driver version using vulkaninfo or kernel version as fallback.
+    /// If deviceIdHex is provided, it extracts the driver specifically for that GPU.
     /// </summary>
-    public static string GetRealDriverVersion()
+    public static string GetRealDriverVersion(string deviceIdHex = "")
     {
         try
         {
@@ -169,12 +193,37 @@ public static class GpuFeatureDetection
             {
                 string vInfo = p.StandardOutput.ReadToEnd();
                 p.WaitForExit();
-                var match = Regex.Match(vInfo, @"driverInfo\s*=\s*(.*)");
-                if (match.Success) return match.Groups[1].Value.Trim();
+                
+                if (!string.IsNullOrEmpty(deviceIdHex))
+                {
+                    string target = deviceIdHex.Replace("0x", "").Trim().ToUpper();
+                    var gpuBlocks = Regex.Split(vInfo, @"GPU\d+:");
+                    
+                    for (int i = 1; i < gpuBlocks.Length; i++)
+                    {
+                        var block = gpuBlocks[i];
+                        var devMatch = Regex.Match(block, @"deviceID\s*=\s*0x([0-9a-fA-F]+)", RegexOptions.IgnoreCase);
+                        
+                        if (devMatch.Success && devMatch.Groups[1].Value.ToUpper() == target)
+                        {
+                            var match = Regex.Match(block, @"driverInfo\s*=\s*(.*)");
+                            if (match.Success) return match.Groups[1].Value.Trim();
+                        }
+                    }
+                    // Target was specified but not found. We intentionally skip the generic 
+                    // first-match fallback so it drops down to the Kernel version at the bottom.
+                }
+                else
+                {
+                    // Fallback to first match ONLY if no specific target was requested
+                    var fallbackMatch = Regex.Match(vInfo, @"driverInfo\s*=\s*(.*)");
+                    if (fallbackMatch.Success) return fallbackMatch.Groups[1].Value.Trim();
+                }
             }
         }
         catch { }
 
+        // The safe fallback for unsupported/missing GPUs
         string kernel = GetKernelVersion();
         if (!string.IsNullOrEmpty(kernel)) return $"{kernel} (Kernel)";
         return "Unknown";
@@ -635,6 +684,50 @@ public static class GpuFeatureDetection
         }
 
         return false;
+    }
+
+
+    /// <summary>
+    /// Checks if Vulkan is supported by verifying the specific GPU deviceID in vulkaninfo --summary.
+    /// Falls back to checking ICD files if vulkaninfo fails or is missing.
+    /// </summary>
+    public static bool CheckVulkanSupport(string deviceIdHex, params string[] candidateFilenames)
+    {
+        try
+        {
+            var psi = new ProcessStartInfo("vulkaninfo", "--summary")
+            {
+                RedirectStandardOutput = true, UseShellExecute = false, CreateNoWindow = true
+            };
+            using var p = Process.Start(psi);
+            if (p != null)
+            {
+                string output = p.StandardOutput.ReadToEnd();
+                p.WaitForExit();
+                
+                // If vulkaninfo ran and gave standard output
+                if (output.Contains("VULKANINFO") || output.Contains("Devices:"))
+                {
+                    string target = deviceIdHex.Replace("0x", "").Trim().ToUpper();
+                    var matches = Regex.Matches(output, @"deviceID\s*=\s*0x([0-9a-fA-F]+)", RegexOptions.IgnoreCase);
+                    
+                    foreach (Match m in matches)
+                    {
+                        if (m.Groups[1].Value.ToUpper() == target)
+                        {
+                            return true;
+                        }
+                    }
+                    
+                    // vulkaninfo ran successfully, but this specific GPU was not listed
+                    return false;
+                }
+            }
+        }
+        catch { }
+
+        // Fallback: vulkaninfo command is missing or broken, try the ICD files
+        return CheckVulkanIcdInstalled(candidateFilenames);
     }
 
     /// <summary>


### PR DESCRIPTION
Fixes the Vulkan issue described in #90 . The device ID match is required to show Vulkan as supported API (if vulkaninfo runs properly on the host system).