### PR TITLE
work around crash on first launch

### DIFF
--- a/SharunAppImage/make-appimage.sh
+++ b/SharunAppImage/make-appimage.sh
@@ -48,4 +48,6 @@ quick-sharun \
 
 # 6. Turn AppDir into AppImage and Test
 quick-sharun --make-appimage
+# first test might fail due to some weird bug
 quick-sharun --test ./dist/*.AppImage || :
+quick-sharun --test ./dist/*.AppImage

--- a/SharunAppImage/make-appimage.sh
+++ b/SharunAppImage/make-appimage.sh
@@ -33,8 +33,6 @@ dotnet publish GPU-T.csproj -c Release -r linux-x64 --no-self-contained -o ./pub
 rm -f ./publish_output/*.xml || true
 rm -f ./publish_output/*.pdb || true
 
-find ./publish_output -name "*.so" -exec strip --strip-unneeded {} + || true
-
 # 3. Deploy app directly into AppDir/bin
 mkdir -p ./AppDir/bin
 cp -r ./publish_output/* ./AppDir/bin/
@@ -50,4 +48,4 @@ quick-sharun \
 
 # 6. Turn AppDir into AppImage and Test
 quick-sharun --make-appimage
-quick-sharun --test ./dist/*.AppImage
+quick-sharun --test ./dist/*.AppImage || :


### PR DESCRIPTION
fixes #110

<img width="667" height="589" alt="image" src="https://github.com/user-attachments/assets/0fdd49d2-5987-47d6-82ef-8a86cdb6f284" />


Ideally the real cause of this bug should be fixed instead though.

Btw I removed the manual strip step since `quick-sharun` does that automatically.