### PR TITLE
Fix AppImage First-Launch Crash (HarfBuzz Symbol Collision)

### DIFF
--- a/SharunAppImage/make-appimage.sh
+++ b/SharunAppImage/make-appimage.sh
@@ -37,9 +37,12 @@ rm -f ./publish_output/*.pdb || true
 mkdir -p ./AppDir/bin
 cp -r ./publish_output/* ./AppDir/bin/
 
-rm -f ./AppDir/bin/libHarfBuzzSharp.so || true
+HARFBUZZ_PATH=$(ldconfig -p | grep libharfbuzz.so.0 | head -n 1 | awk '{print $4}')
 
-ln -s /usr/lib/libharfbuzz.so.0 ./AppDir/bin/libHarfBuzzSharp.so
+cp "$HARFBUZZ_PATH" ./AppDir/bin/libharfbuzz.so.0
+
+rm -f ./AppDir/bin/libHarfBuzzSharp.so || true
+ln -s libharfbuzz.so.0 ./AppDir/bin/libHarfBuzzSharp.so
 
 cp ./SharunAppImage/gpu-t.desktop ./AppDir/
 
@@ -53,5 +56,4 @@ quick-sharun \
 # 6. Turn AppDir into AppImage and Test
 quick-sharun --make-appimage
 # first test might fail due to some weird bug
-quick-sharun --test ./dist/*.AppImage || :
 quick-sharun --test ./dist/*.AppImage

--- a/SharunAppImage/make-appimage.sh
+++ b/SharunAppImage/make-appimage.sh
@@ -54,13 +54,13 @@ cp -r ./publish_output/* ./AppDir/bin/
 # ==============================================================================
 
 # 3.1. Dynamically find the path of the native HarfBuzz on the CI/CD build runner
-HARFBUZZ_PATH=$(ldconfig -p | grep libharfbuzz.so.0 | head -n 1 | awk '{print $4}')
+HARFBUZZ_PATH=$(ldconfig -p | awk '/libharfbuzz.so.0/ {print $4; exit}')
 
 # 3.2. Copy it directly into our AppImage payload
 cp "$HARFBUZZ_PATH" ./AppDir/bin/libharfbuzz.so.0
 
 # 3.3. Delete SkiaSharp's bundled wrapper
-rm -f ./AppDir/bin/libHarfBuzzSharp.so || true
+rm -f ./AppDir/bin/libHarfBuzzSharp.so
 
 # 3.4. Create a RELATIVE symlink. When SkiaSharp asks for 'libHarfBuzzSharp.so', 
 # it gets seamlessly redirected to our bundled 'libharfbuzz.so.0' sitting right 

--- a/SharunAppImage/make-appimage.sh
+++ b/SharunAppImage/make-appimage.sh
@@ -37,11 +37,34 @@ rm -f ./publish_output/*.pdb || true
 mkdir -p ./AppDir/bin
 cp -r ./publish_output/* ./AppDir/bin/
 
+# ==============================================================================
+# FIX FOR SKIASHARP / HARFBUZZ SYMBOL COLLISION (SIGSEGV on First Launch)
+# ==============================================================================
+# PROBLEM: 
+# SkiaSharp bundles its own 'libHarfBuzzSharp.so'. The Linux host system uses 
+# 'libharfbuzz.so.0' for native OS font scanning. Because they share the exact 
+# same symbol names, they both load into memory. When SkiaSharp tries to free a 
+# font object created by the OS library, the memory manager panics and throws a 
+# "free(): invalid pointer" crash.
+#
+# SOLUTION: 
+# Force both SkiaSharp and the Linux system to use the exact same, single library.
+# We do this by bundling the build runner's native HarfBuzz into our AppImage, 
+# and replacing SkiaSharp's wrapper with a RELATIVE symlink.
+# ==============================================================================
+
+# 3.1. Dynamically find the path of the native HarfBuzz on the CI/CD build runner
 HARFBUZZ_PATH=$(ldconfig -p | grep libharfbuzz.so.0 | head -n 1 | awk '{print $4}')
 
+# 3.2. Copy it directly into our AppImage payload
 cp "$HARFBUZZ_PATH" ./AppDir/bin/libharfbuzz.so.0
 
+# 3.3. Delete SkiaSharp's bundled wrapper
 rm -f ./AppDir/bin/libHarfBuzzSharp.so || true
+
+# 3.4. Create a RELATIVE symlink. When SkiaSharp asks for 'libHarfBuzzSharp.so', 
+# it gets seamlessly redirected to our bundled 'libharfbuzz.so.0' sitting right 
+# next to it. Memory collision prevented!
 ln -s libharfbuzz.so.0 ./AppDir/bin/libHarfBuzzSharp.so
 
 cp ./SharunAppImage/gpu-t.desktop ./AppDir/

--- a/SharunAppImage/make-appimage.sh
+++ b/SharunAppImage/make-appimage.sh
@@ -78,5 +78,4 @@ quick-sharun \
 
 # 6. Turn AppDir into AppImage and Test
 quick-sharun --make-appimage
-# first test might fail due to some weird bug
 quick-sharun --test ./dist/*.AppImage

--- a/SharunAppImage/make-appimage.sh
+++ b/SharunAppImage/make-appimage.sh
@@ -37,6 +37,10 @@ rm -f ./publish_output/*.pdb || true
 mkdir -p ./AppDir/bin
 cp -r ./publish_output/* ./AppDir/bin/
 
+rm -f ./AppDir/bin/libHarfBuzzSharp.so || true
+
+ln -s /usr/lib/libharfbuzz.so.0 ./AppDir/bin/libHarfBuzzSharp.so
+
 cp ./SharunAppImage/gpu-t.desktop ./AppDir/
 
 # 4. Build the heavily optimized container


### PR DESCRIPTION
This PR completely resolves the `free(): invalid pointer` (SIGSEGV) crash that occurred during the AppImage's first launch. 

This replaces the previous CI workaround (PR #111) with a permanent, structural fix to how we package the AppImage payload.

The Root Cause (The First-Launch Crash): As discussed in the original issue, the app was crashing on first launch when generating the font cache. After further investigation, this was confirmed to be a known symbol collision issue (tracking upstream: mono/SkiaSharp#3038).

Because `libHarfBuzzSharp.so` (bundled by SkiaSharp) exports the exact same C function names as the native Linux `libharfbuzz.so.0` used by the host OS, the dynamic linker cross-wired the memory allocations. SkiaSharp would attempt to `free()` a font object that the system's `libharfbuzz` had allocated, causing `glibc` to panic and kill the app to prevent memory corruption. 

The Fix: Instead of relying on complex linker flags, we now force both SkiaSharp and the underlying OS to use a single, unified instance of HarfBuzz inside the AppImage. 

By making this a relative symlink inside the `AppDir`, the AppImage remains 100% portable. It completely bypasses the symbol collision because there is now only one component managing HarfBuzz memory.