### PR TITLE
Prevent GetPcieInfo func returning pcie width higher than hardware's physical max capability

### DIFF
--- a/Services/Utilities/GpuFeatureDetection.cs
+++ b/Services/Utilities/GpuFeatureDetection.cs
@@ -482,6 +482,16 @@ public static class GpuFeatureDetection
                 currentGen = "Unknown";
             }
         }
+
+        // Ensure current width does not exceed max width
+        int.TryParse(maxWidthStr, out int maxWidthInt);
+        int.TryParse(currentWidth, out int currentWidthInt);
+
+        if(currentWidthInt > maxWidthInt && maxWidthInt > 0)
+        {
+            currentWidth = maxWidthStr;
+        }
+
         return $"{capability} @ x{currentWidth} {currentGen}";
     }
 


### PR DESCRIPTION
Addresses bug in #123 